### PR TITLE
mobilecoinofficial -> mobilecoinfoundation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "mobilecoin"]
 	path = mobilecoin
-	url = https://github.com/mobilecoinofficial/mobilecoin
+	url = https://github.com/mobilecoinfoundation/mobilecoin
 	branch = master


### PR DESCRIPTION
### Motivation

The mobilecoin repo has transferred ownership from the mobielcoinofficial org to the mobilecoinfoundation org. This PR updates the submodule accordingly.